### PR TITLE
Set up static code analysis with lintr and fix lints

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^Read-and-delete-me$
 ^README\.md$
 ^\.github$
+^\.lintr$

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,10 @@
+linters: linters_with_tags(
+    tags = c("best_practices", "common_mistakes", "correctness", "efficiency", "robustness"),
+    undesirable_function_linter = NULL,
+    implicit_integer_linter = NULL,
+    extraction_operator_linter = NULL,
+    commented_code_linter = NULL,
+    cyclocomp_linter = NULL,
+    nonportable_path_linter = NULL,
+    function_argument_linter = NULL
+  )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Date: 2023-03-06
 Author: Pierre-Yves Boelle, Thomas Obadia
 Maintainer: Thomas Obadia <thomas.obadia@pasteur.fr>
 Depends:
-    R (>= 2.13.0)
+    R (>= 3.3.0)
 Imports:
     MASS
 Description: Estimation of reproduction numbers for disease outbreak, based on

--- a/R/check.incid.R
+++ b/R/check.incid.R
@@ -74,10 +74,10 @@ check.incid <- function(
   
 {
   #Various class and integrity checks
-  if (is.numeric(incid) | is.character(incid) | inherits(incid, "Date")) {
+  if (is.numeric(incid) || is.character(incid) || inherits(incid, "Date")) {
     
     #Basic possibility is incidence provided by date of symptoms onset for each patient
-    if (is.character(incid) | inherits(incid, "Date")) {
+    if (is.character(incid) || inherits(incid, "Date")) {
       # try to convert incid to dates using standard formats "%Y-%m-%d" / "%Y/%m/%d"
       tmp <- as.Date(incid)
       # if passed, incid was a vector of dates - convert to factor, making sure that levels correspond to min - max by time-step
@@ -110,7 +110,7 @@ check.incid <- function(
     }
     
     #Try to determine if t is numeric or date
-    if (!any(is.na(suppressWarnings(as.numeric(t)))) & !inherits(t, "Date")) {
+    if (!any(is.na(suppressWarnings(as.numeric(t)))) && !inherits(t, "Date")) {
       #names are numeric 
       t <- as.numeric(t)
       incid <- incid[order(t)]
@@ -167,7 +167,7 @@ check.incid <- function(
           t <- as.Date(names(table(epicurve.object$stratum3)))
         }
         
-        if (is.null(t) | is.null(incid)) {
+        if (is.null(t) || is.null(incid)) {
           stop("Could not find 'dates', 'weeks' or 'month' in epid")
         }
       } 

--- a/R/check.incid.R
+++ b/R/check.incid.R
@@ -113,8 +113,10 @@ check.incid <- function(
     if (!any(is.na(suppressWarnings(as.numeric(t)))) && !inherits(t, "Date")) {
       #names are numeric 
       t <- as.numeric(t)
-      incid <- incid[order(t)]
-      t <- t[order(t)]
+      
+      t_order <- order(t)
+      incid <- incid[t_order]
+      t <- t[t_order]
       if (length(unique(t)) != length(t)) {stop("duplicates t values or duplicate names in incid")}
       # check that all t values are present with at last time.step interval
       if (min(diff(t)) < time.step) stop("t values must be at least time.step = ",time.step," units apart from each other")
@@ -127,8 +129,9 @@ check.incid <- function(
     #Try dates with most common format
     else if (suppressWarnings((!is.na(strptime(t[1], format="%Y-%m-%d"))) | (!is.na(strptime(t[1], format="%Y/%m/%d"))))) {
       t <- as.Date(t)
-      incid <- incid[order(t)]
-      t <- t[order(t)]
+      t_order <- order(t)
+      incid <- incid[t_order]
+      t <- t[t_order]
       if (length(unique(t)) != length(t)) {stop("duplicates t values or duplicate names in incid")}
       # check that all t values are present with at last time.step interval
       if (min(as.numeric(diff(t))) < time.step) stop("t values must be at least time.step = ",time.step," units apart from each other")

--- a/R/check.incid.R
+++ b/R/check.incid.R
@@ -85,7 +85,7 @@ check.incid <- function(
       if ( as.numeric(min(diff(sort(unique(tmp))))) < time.step) {
         idx <- which(as.numeric(diff(sort(unique(tmp)))) < time.step)[1]
         dt.too.close <- sort(unique(tmp))[(idx-1):idx]      
-        stop(paste("dates", paste(dt.too.close,collapse=";"),"must be at least time.step =",time.step,"units apart from each other"))
+        stop("dates ", paste(dt.too.close,collapse=";")," must be at least time.step = ",time.step," units apart from each other")
       }
       t <- as.character(seq(min(tmp,na.rm=T), max(tmp,na.rm=T),by=time.step))      
       incid <- as.numeric(table(factor(incid, levels=t)))
@@ -117,7 +117,7 @@ check.incid <- function(
       t <- t[order(t)]
       if (length(unique(t)) != length(t)) {stop("duplicates t values or duplicate names in incid")}
       # check that all t values are present with at last time.step interval
-      if (min(diff(t)) < time.step) stop(paste("t values must be at least time.step =",time.step," units apart from each other"))
+      if (min(diff(t)) < time.step) stop("t values must be at least time.step = ",time.step," units apart from each other")
       tmp <- merge(data.frame(t=t, incid=incid),data.frame(t=seq(min(t,na.rm=T),max(t,na.rm=T),by=time.step)),all.y=T)
       tmp$incid[is.na(tmp$incid)] <- 0
       incid <- tmp$incid
@@ -131,7 +131,7 @@ check.incid <- function(
       t <- t[order(t)]
       if (length(unique(t)) != length(t)) {stop("duplicates t values or duplicate names in incid")}
       # check that all t values are present with at last time.step interval
-      if (min(as.numeric(diff(t))) < time.step) stop(paste("t values must be at least time.step =",time.step," units apart from each other"))
+      if (min(as.numeric(diff(t))) < time.step) stop("t values must be at least time.step = ",time.step," units apart from each other")
       tmp <- merge(data.frame(t=t, incid=incid),data.frame(t=seq(min(t,na.rm=T),max(t,na.rm=T),by=time.step)),all.y=T)
       tmp$incid[is.na(tmp$incid)] <- 0
       incid <- tmp$incid

--- a/R/check.incid.R
+++ b/R/check.incid.R
@@ -110,7 +110,7 @@ check.incid <- function(
     }
     
     #Try to determine if t is numeric or date
-    if (!any(is.na(suppressWarnings(as.numeric(t)))) && !inherits(t, "Date")) {
+    if (!anyNA(suppressWarnings(as.numeric(t))) && !inherits(t, "Date")) {
       #names are numeric 
       t <- as.numeric(t)
       
@@ -186,7 +186,7 @@ check.incid <- function(
   }
   
   #Incid is not negative or missing
-  if (any(incid < 0) || any(is.na(incid))) {
+  if (any(incid < 0) || anyNA(incid)) {
     stop("'incid' should be positive and non missing")
   }
   

--- a/R/check.incid.R
+++ b/R/check.incid.R
@@ -117,7 +117,7 @@ check.incid <- function(
       t_order <- order(t)
       incid <- incid[t_order]
       t <- t[t_order]
-      if (length(unique(t)) != length(t)) {stop("duplicates t values or duplicate names in incid")}
+      if (anyDuplicated(t) > 0) {stop("duplicates t values or duplicate names in incid")}
       # check that all t values are present with at last time.step interval
       if (min(diff(t)) < time.step) stop("t values must be at least time.step = ",time.step," units apart from each other")
       tmp <- merge(data.frame(t=t, incid=incid),data.frame(t=seq(min(t,na.rm=TRUE),max(t,na.rm=TRUE),by=time.step)),all.y=TRUE)
@@ -132,7 +132,7 @@ check.incid <- function(
       t_order <- order(t)
       incid <- incid[t_order]
       t <- t[t_order]
-      if (length(unique(t)) != length(t)) {stop("duplicates t values or duplicate names in incid")}
+      if (anyDuplicated(t) > 0) {stop("duplicates t values or duplicate names in incid")}
       # check that all t values are present with at last time.step interval
       if (min(as.numeric(diff(t))) < time.step) stop("t values must be at least time.step = ",time.step," units apart from each other")
       tmp <- merge(data.frame(t=t, incid=incid),data.frame(t=seq(min(t,na.rm=TRUE),max(t,na.rm=TRUE),by=time.step)),all.y=TRUE)

--- a/R/check.incid.R
+++ b/R/check.incid.R
@@ -100,7 +100,7 @@ check.incid <- function(
           
         }
         else {
-          t <- 1:length(incid)
+          t <- seq_along(incid)
           t[-1] <- t[-1]*time.step - (time.step-1)
         }
       }
@@ -141,7 +141,7 @@ check.incid <- function(
     #Doesn't match any date format or custom numeric sequence
     else {
       #replace t by integer sequence
-      t <- 1:length(incid)
+      t <- seq_along(incid)
     }
   } 
   

--- a/R/check.incid.R
+++ b/R/check.incid.R
@@ -87,7 +87,7 @@ check.incid <- function(
         dt.too.close <- sort(unique(tmp))[(idx-1):idx]      
         stop("dates ", paste(dt.too.close,collapse=";")," must be at least time.step = ",time.step," units apart from each other")
       }
-      t <- as.character(seq(min(tmp,na.rm=T), max(tmp,na.rm=T),by=time.step))      
+      t <- as.character(seq(min(tmp,na.rm=TRUE), max(tmp,na.rm=TRUE),by=time.step))      
       incid <- as.numeric(table(factor(incid, levels=t)))
     }
     
@@ -118,7 +118,7 @@ check.incid <- function(
       if (length(unique(t)) != length(t)) {stop("duplicates t values or duplicate names in incid")}
       # check that all t values are present with at last time.step interval
       if (min(diff(t)) < time.step) stop("t values must be at least time.step = ",time.step," units apart from each other")
-      tmp <- merge(data.frame(t=t, incid=incid),data.frame(t=seq(min(t,na.rm=T),max(t,na.rm=T),by=time.step)),all.y=T)
+      tmp <- merge(data.frame(t=t, incid=incid),data.frame(t=seq(min(t,na.rm=TRUE),max(t,na.rm=TRUE),by=time.step)),all.y=TRUE)
       tmp$incid[is.na(tmp$incid)] <- 0
       incid <- tmp$incid
       t <- tmp$t
@@ -132,7 +132,7 @@ check.incid <- function(
       if (length(unique(t)) != length(t)) {stop("duplicates t values or duplicate names in incid")}
       # check that all t values are present with at last time.step interval
       if (min(as.numeric(diff(t))) < time.step) stop("t values must be at least time.step = ",time.step," units apart from each other")
-      tmp <- merge(data.frame(t=t, incid=incid),data.frame(t=seq(min(t,na.rm=T),max(t,na.rm=T),by=time.step)),all.y=T)
+      tmp <- merge(data.frame(t=t, incid=incid),data.frame(t=seq(min(t,na.rm=TRUE),max(t,na.rm=TRUE),by=time.step)),all.y=TRUE)
       tmp$incid[is.na(tmp$incid)] <- 0
       incid <- tmp$incid
       t <- as.Date(as.character(tmp$t))

--- a/R/est.GT.R
+++ b/R/est.GT.R
@@ -67,7 +67,7 @@ est.GT <- function(
   # Data integrity check
   
   #Vector dimension
-  if ((is.null(infector.onset.dates) | is.null(infectee.onset.dates)) && is.null(serial.interval)) {
+  if ((is.null(infector.onset.dates) || is.null(infectee.onset.dates)) && is.null(serial.interval)) {
     stop("Please provide either 'serial interval' alone or both 'infector.onset.dates' and 'infectee.onset.dates'.")
   }
   
@@ -90,7 +90,7 @@ est.GT <- function(
     }
     
     
-    else if (!is.numeric(infector.onset.dates) & !inherits(infector.onset.dates, "Date")) {
+    else if (!is.numeric(infector.onset.dates) && !inherits(infector.onset.dates, "Date")) {
       stop("onset.dates vector does not contain a compatible format format (numeric, integer, character, Date)")
     }
     

--- a/R/est.GT.R
+++ b/R/est.GT.R
@@ -145,7 +145,7 @@ est.GT <- function(
     mean <- shape/rate
     sd <- sqrt(shape)/rate
     
-    if (request.plot == TRUE) {
+    if (request.plot) {
       hist(serial.interval, prob=TRUE, col="deepskyblue", xlim=c(0,max(serial.interval)), ylim=c(0,(max(density(serial.interval)$y))+0.1), xlab="Serial Interval", ylab="PDF", main="Serial Interval and Generation Time density")
       curve(dgamma(x, shape=shape, rate=rate), add=TRUE, col="red")
     }
@@ -157,7 +157,7 @@ est.GT <- function(
     mean <- scale*exp(lgamma(1 + 1/shape))
     sd <- sqrt(scale^2 * (exp(lgamma(1+2/shape)) - (exp(lgamma(1+1/shape)))^2))
     
-    if (request.plot == TRUE) {
+    if (request.plot) {
       hist(serial.interval, prob=TRUE, col="deepskyblue", xlim=c(0,max(serial.interval)), ylim=c(0,(max(density(serial.interval)$y))+0.1), xlab="Serial Interval", ylab="PDF", main="Serial Interval and Generation Time density")
       curve(dweibull(x, shape=shape, scale=scale), add=TRUE, col="red")
     }
@@ -169,7 +169,7 @@ est.GT <- function(
     mean <- exp(1/2 * sdlog^2 + meanlog)
     sd <-sqrt(exp(2*meanlog + sdlog^2) * (exp(sdlog^2) - 1))
     
-    if (request.plot == TRUE) {
+    if (request.plot) {
       hist(serial.interval, prob=TRUE, col="deepskyblue", xlim=c(0,max(serial.interval)), ylim=c(0,(max(density(serial.interval)$y))+0.1), xlab="Serial Interval", ylab="PDF", main="Serial Interval and Generation Time density")
       curve(dlnorm(x, meanlog=meanlog, sdlog=sdlog), add=TRUE, col="red")
     }

--- a/R/est.R0.AR.R
+++ b/R/est.R0.AR.R
@@ -102,11 +102,11 @@ est.R0.AR <- function(
     }
     
     if (any(c(incid,pop.size) <= 0 )){
-      stop(paste("'incid' =",incid," and 'pop.size' =",pop.size,"must be nonnegative"))
+      stop("'incid' = ",incid," and 'pop.size' = ",pop.size," must be nonnegative")
     }
     
     if (pop.size < incid){
-      stop(paste("'pop.size' =",pop.size,"must be greater than 'incid'= ", incid))
+      stop("'pop.size' = ",pop.size," must be greater than 'incid'= ", incid)
     }
     
     #Actual AR is now computed
@@ -118,7 +118,7 @@ est.R0.AR <- function(
     
     #Obviously AR is between 0 and 1
     if (AR <= 0 || AR >= 1) {
-      stop(paste("'AR' =",AR,"must be between 0 and 1"))
+      stop("'AR' = ",AR," must be between 0 and 1")
     }
     
     if (is.null(pop.size)) {

--- a/R/est.R0.AR.R
+++ b/R/est.R0.AR.R
@@ -90,7 +90,7 @@ est.R0.AR <- function(
   }
   
   #Required : either (AR, incidence) or (AR, pop.size) to start simulation
-  if (is.null(AR) & any(c(is.null(incid),is.null(pop.size)))) {
+  if (is.null(AR) && any(c(is.null(incid),is.null(pop.size)))) {
     stop("Either 'AR' alone or both 'AR / incid' and 'pop.size' must be provided")
   }
   
@@ -117,7 +117,7 @@ est.R0.AR <- function(
   else {
     
     #Obviously AR is between 0 and 1
-    if (AR <= 0 | AR >= 1) {
+    if (AR <= 0 || AR >= 1) {
       stop(paste("'AR' =",AR,"must be between 0 and 1"))
     }
     

--- a/R/est.R0.AR.R
+++ b/R/est.R0.AR.R
@@ -78,7 +78,7 @@ est.R0.AR <- function(
   
 {
   # Various class and integrity checks
-  if (checked == FALSE) {
+  if (!checked) {
     integrity.checks(epid=epid, GT=NULL, t=t, begin=NULL, end=NULL, date.first.obs=NULL, time.step=NULL, AR, S0, methods="AR")
   }
   

--- a/R/est.R0.EG.R
+++ b/R/est.R0.EG.R
@@ -95,7 +95,7 @@ est.R0.EG <-function(
   CALL <- match.call()
   
   # Various class and integrity check
-  if (checked == FALSE) {
+  if (!checked) {
     parameters <- integrity.checks(epid=epid, GT=GT, t=t, begin=begin, end=end, date.first.obs=date.first.obs, time.step=time.step, AR=NULL, S0=NULL, methods="EG")
     begin <- parameters$begin
     end <- parameters$end

--- a/R/est.R0.ML.R
+++ b/R/est.R0.ML.R
@@ -119,7 +119,7 @@ est.R0.ML <- function(
   begin.nb <- which(epid$t == begin)
   end.nb <- which(epid$t == end)
   
-  if(!is.null(import) & length(import) != length(epid$incid)) stop("Import vector and incidence vector do not have the same length.")
+  if(!is.null(import) && length(import) != length(epid$incid)) stop("Import vector and incidence vector do not have the same length.")
   if (is.null(import)) import <- rep(0, length(epid$incid))
   
   #  if (impute.incid == TRUE) {
@@ -142,7 +142,7 @@ est.R0.ML <- function(
   }
   res.R <- optimize(fit.epid,log(range),GT=GT,epid=epid,import=import,maximum=TRUE)
   
-  if ((exp(res.R$maximum) == range[1]) | (exp(res.R$maximum) == range[2])) { 
+  if ((exp(res.R$maximum) == range[1]) || (exp(res.R$maximum) == range[2])) { 
     warning("Algorithm converged to boundary. Try increasing 'range'")
   }
   

--- a/R/est.R0.ML.R
+++ b/R/est.R0.ML.R
@@ -110,7 +110,7 @@ est.R0.ML <- function(
 {
   CALL <- match.call()
   # Various class and integrity checks
-  if (checked == FALSE) {
+  if (!checked) {
     parameters <- integrity.checks(epid=epid, GT=GT, t=t, begin=begin, end=end, date.first.obs=date.first.obs, time.step=time.step, AR=NULL, S0=NULL, methods="ML")
     begin <- parameters$begin
     end <- parameters$end
@@ -136,7 +136,7 @@ est.R0.ML <- function(
   
   #Make a likelihood that can be optimized
   log.R <- log(1) #initial value is taken at 1
-  if (unknown.GT==TRUE) {
+  if (unknown.GT) {
     optimized.val <- optim(c(log.R, GT$mean, GT$sd), fit.epid.optim, epid=epid, import=import, control=list(fnscale=-1))$par
     GT <- generation.time("gamma", c(optimized.val[2], optimized.val[3]))
   }
@@ -160,7 +160,7 @@ est.R0.ML <- function(
   Rsquared <- (tmp$null.deviance-tmp$deviance)/(tmp$null.deviance)
   
   #If data are censored and need to be imputed, recursive call of ML method
-  if (impute.incid == TRUE) {
+  if (impute.incid) {
     R0.val.i <- vector()
     R0.val.i[1] <- exp(res.R$maximum)
     new.incid <- impute.incid(c(0,0), epid.orig, R0.val.i[1], GT)
@@ -188,7 +188,7 @@ est.R0.ML <- function(
     new.epid <- check.incid(incid=new.incid, time.step=time.step, date.first.obs=(epid$t[1]-length(GT$GT)))
   }
   
-  if (impute.incid == FALSE) {
+  if (!impute.incid) {
     return (structure(list(R=exp(res.R$maximum), conf.int=c(exp(R.min$root), exp(R.max$root)), epid=epid.orig, GT=GT, begin=begin, begin.nb=begin.nb, end=end, end.nb=end.nb, pred=pred, Rsquared=Rsquared, call=CALL, method="Maximum Likelihood", method.code="ML"),class="R0.R"))
   }
   else {

--- a/R/est.R0.ML.R
+++ b/R/est.R0.ML.R
@@ -142,7 +142,7 @@ est.R0.ML <- function(
   }
   res.R <- optimize(fit.epid,log(range),GT=GT,epid=epid,import=import,maximum=TRUE)
   
-  if ((exp(res.R$maximum) == range[1]) || (exp(res.R$maximum) == range[2])) { 
+  if (exp(res.R$maximum) %in% c(range[1], range[2])) { 
     warning("Algorithm converged to boundary. Try increasing 'range'")
   }
   

--- a/R/est.R0.ML.R
+++ b/R/est.R0.ML.R
@@ -189,7 +189,7 @@ est.R0.ML <- function(
   }
   
   if (!impute.incid) {
-    return (structure(list(R=exp(res.R$maximum), conf.int=c(exp(R.min$root), exp(R.max$root)), epid=epid.orig, GT=GT, begin=begin, begin.nb=begin.nb, end=end, end.nb=end.nb, pred=pred, Rsquared=Rsquared, call=CALL, method="Maximum Likelihood", method.code="ML"),class="R0.R"))
+    return (structure(list(R=exp(res.R$maximum), conf.int=exp(c(R.min$root, R.max$root)), epid=epid.orig, GT=GT, begin=begin, begin.nb=begin.nb, end=end, end.nb=end.nb, pred=pred, Rsquared=Rsquared, call=CALL, method="Maximum Likelihood", method.code="ML"),class="R0.R"))
   }
   else {
     return (structure(list(R=R0.best, conf.int=conf.int, epid=new.epid, epid.orig=epid.orig, GT=GT, begin=new.epid$t[1], begin.nb=1, end=end, end.nb=which(new.epid$t == end), pred=pred, Rsquared=Rsquared, call=CALL, method="Maximum Likelihood", method.code="ML"),class="R0.R"))

--- a/R/est.R0.SB.R
+++ b/R/est.R0.SB.R
@@ -94,7 +94,7 @@ est.R0.SB <- function(
   CALL <- match.call()
   
   #Various class and integrity checks
-  if (checked == FALSE) {
+  if (!checked) {
     parameters <- integrity.checks(epid=epid, GT=GT, t=t, begin=begin, end=end, date.first.obs=date.first.obs, time.step=time.step, AR=NULL, S0=NULL, methods="SB")
     begin <- parameters$begin
     end <- parameters$end
@@ -116,7 +116,7 @@ est.R0.SB <- function(
   
   ## Initial distribution of Rt
   
-  if (force.prior == FALSE) {
+  if (!force.prior) {
     #For the first iteration, we admit Rt to be following a unfiorm distribution
     #on [0 ; maximum.delta.incid]
     delta.incid <- epid$incid[2:length(epid$incid)] - epid$incid[1:(length(epid$incid)-1)]

--- a/R/est.R0.SB.R
+++ b/R/est.R0.SB.R
@@ -148,7 +148,7 @@ est.R0.SB <- function(
     
     tmp.proba.Rt <- exp(log(proba.Rt[[s-1]]) + tmp)
     #Break if incidence data starts producing NaN values
-    if ((sum(tmp.proba.Rt) == 0) | NaN %in% (sum(tmp.proba.Rt))) {
+    if ((sum(tmp.proba.Rt) == 0) || NaN %in% (sum(tmp.proba.Rt))) {
       end.nb <- s-1
       end <- epid$t[end.nb]
       break

--- a/R/est.R0.TD.R
+++ b/R/est.R0.TD.R
@@ -229,7 +229,7 @@ est.R0.TD <- function(
   
   #We now have enough data to compute R (from infection network P)
   #along with its 2.5% and 97.5% quantiles (from multiple simulations and p)
-  R.WT <- apply(P,1,sum)    # Wallinga and Teunis definition
+  R.WT <- rowSums(P)    # Wallinga and Teunis definition
   R.corrected <- R.WT/(cumsum(GT.pad[1:Tmax]))[Tmax:1]   # Corrected for real time
   if (is.na(R.corrected[length(epid$incid)])) {
     R.corrected[length(epid$incid)] <- 0

--- a/R/est.R0.TD.R
+++ b/R/est.R0.TD.R
@@ -109,7 +109,7 @@ est.R0.TD <- function(
   
   #Various class and integrity checks
   #transforms epidemic to the right format
-  if (checked == FALSE) {
+  if (!checked) {
     parameters <- integrity.checks(epid=epid,GT=GT, t=t, begin=begin, end=end, date.first.obs=date.first.obs, time.step=time.step, AR=NULL, S0=NULL, methods="TD")
     begin <- parameters$begin
     end <- parameters$end
@@ -262,7 +262,7 @@ est.R0.TD <- function(
   conf.int <- matrix(data=NA, nrow=end.nb, ncol=2)
   colnames(conf.int) <- c("lower", "upper")
   
-  if (correct == TRUE) {
+  if (correct) {
     R <- R.corrected[begin.nb:end.nb]
     conf.int[begin.nb:end.nb,1] <- quant.simu.corrected[begin.nb:end.nb,1]
     conf.int[begin.nb:end.nb,2] <- quant.simu.corrected[begin.nb:end.nb,2]

--- a/R/est.R0.TD.R
+++ b/R/est.R0.TD.R
@@ -128,7 +128,7 @@ est.R0.TD <- function(
   end <- which(t==-1)
   if (length(start) > 0 && length(end) > 0) { 
     longest <- max(end-start)
-    if (longest > length(GT$GT)) warning(paste("Gap in epidemic curve is longer than the generation interval. Consider using a different GT distribution (maybe with \"truncate=", longest, "\" (length of longest gap))."), sep="")
+    if (longest > length(GT$GT)) warning("Gap in epidemic curve is longer than the generation interval. Consider using a different GT distribution (maybe with \"truncate=", longest, "\" (length of longest gap)).")
   }
   
   #Imported cases should be provided as a vector of the same length as incid.
@@ -149,7 +149,7 @@ est.R0.TD <- function(
   
   #Initial n0 larger than first recorded value is an error
   if (n.t0 > epid$incid[1])  {
-    stop(paste("Provided initial number of cases (n.t0=",n.t0,") is larger than incidence on begin day (=",epid$incid[begin],")"))
+    stop("Provided initial number of cases (n.t0=",n.t0,") is larger than incidence on begin day (=",epid$incid[begin],")")
   }
   
   #Beginning of estimation 

--- a/R/est.R0.TD.R
+++ b/R/est.R0.TD.R
@@ -126,7 +126,7 @@ est.R0.TD <- function(
   t <- diff(c(FALSE, epid$incid==0, FALSE), 1)
   start <- which(t==1)
   end <- which(t==-1)
-  if (length(start) > 0 & length(end) > 0) { 
+  if (length(start) > 0 && length(end) > 0) { 
     longest <- max(end-start)
     if (longest > length(GT$GT)) warning(paste("Gap in epidemic curve is longer than the generation interval. Consider using a different GT distribution (maybe with \"truncate=", longest, "\" (length of longest gap))."), sep="")
   }
@@ -137,7 +137,7 @@ est.R0.TD <- function(
     import <- rep(0, length(epid$incid))
   }
   
-  if (!is.null(import) & (length(import) != length(epid$incid))) {
+  if (!is.null(import) && (length(import) != length(epid$incid))) {
     stop("Vector of imported cases should have the same length as 'epid' data.")
   }
   

--- a/R/estimate.R.R
+++ b/R/estimate.R.R
@@ -114,7 +114,7 @@ estimate.R <- function(
   #AR needs arguments very different from other methods, so it is caled separately if required
   #Optional arguments for each method must be input when calling est.R0. They will be passed
   #to their respective method.
-  for (met in 1:length(methods)) {
+  for (met in seq_along(methods)) {
     if (methods[met] == "AR") {
       estimates[[met]] <- do.call(paste("est.R0",methods[met],sep="."), args=list(incid=epid, AR=AR, pop.size=pop.size, S0=S0, checked=checked, ...))
     }

--- a/R/estimate.R.R
+++ b/R/estimate.R.R
@@ -103,7 +103,7 @@ estimate.R <- function(
   
   #If user inputs an unsupported method, stop. 
   sel.met <- pmatch(methods, c('EG','TD','ML','AR', 'SB'))
-  if (any(is.na(sel.met))) {
+  if (anyNA(sel.met)) {
     stop("Invalid 'methods' argument. Supported methods are 'EG',' ML', 'TD', 'AR', 'SB'.")
   }
   

--- a/R/fit.epid.R
+++ b/R/fit.epid.R
@@ -60,19 +60,19 @@ fit.epid <- function(
   
 {
   R <- exp(log.R)
-  T <- length(epid$incid)
+  Tend <- length(epid$incid)
   GT <- GT$GT
   
   #Simulated epidemic is initiated at 0 and has a length of T+length(GT).
   #This way, we can multiply by GT even with the last value of incidence.
-  sim.epid <- rep(0, T+length(GT))
+  sim.epid <- rep(0, Tend+length(GT))
   
-  for (t in 1:T) {
+  for (t in 1:Tend) {
     sim.epid[t:(t+length(GT)-1)] <- sim.epid[t:(t+length(GT)-1)] + R * epid$incid[t] * GT
   }
   
-  sim.epid <- sim.epid[2:T]
-  logV <- sum(dpois(epid$incid[2:T]-import[2:T],lambda=sim.epid,log=TRUE))
+  sim.epid <- sim.epid[2:Tend]
+  logV <- sum(dpois(epid$incid[2:Tend]-import[2:Tend],lambda=sim.epid,log=TRUE))
   
   if (pred == TRUE) {
     return(pred = c(epid$incid[1],sim.epid))

--- a/R/fit.epid.R
+++ b/R/fit.epid.R
@@ -72,7 +72,7 @@ fit.epid <- function(
   }
   
   sim.epid <- sim.epid[2:T]
-  logV <- sum(dpois(epid$incid[2:T]-import[2:T],lambda=sim.epid,log=T))
+  logV <- sum(dpois(epid$incid[2:T]-import[2:T],lambda=sim.epid,log=TRUE))
   
   if (pred == TRUE) {
     return(pred = c(epid$incid[1],sim.epid))

--- a/R/fit.epid.R
+++ b/R/fit.epid.R
@@ -74,7 +74,7 @@ fit.epid <- function(
   sim.epid <- sim.epid[2:Tend]
   logV <- sum(dpois(epid$incid[2:Tend]-import[2:Tend],lambda=sim.epid,log=TRUE))
   
-  if (pred == TRUE) {
+  if (pred) {
     return(pred = c(epid$incid[1],sim.epid))
   }
   

--- a/R/generation.time.R
+++ b/R/generation.time.R
@@ -143,7 +143,7 @@ generation.time <- function(
       }
     }
   }
-  if (p0 == TRUE) GT[1]=0
+  if (p0) GT[1]=0
   
   time <- 0:(length(GT)-1)
   GT <- GT/sum(GT)

--- a/R/generation.time.R
+++ b/R/generation.time.R
@@ -100,9 +100,9 @@ generation.time <- function(
       tmax <- truncate
     }
     if (first.half) {
-      t.scale <- c(0,0.5+c(0:tmax))
+      t.scale <- c(0,0.5+0:tmax)
     } else {
-      t.scale <- c(0:tmax)
+      t.scale <- 0:tmax
     } 
     if (type == "gamma") {
       a <- mean*mean/(sd*sd) 

--- a/R/generation.time.R
+++ b/R/generation.time.R
@@ -80,11 +80,9 @@ generation.time <- function(
       stop("Values in 'val' must be positive")
     if (sum(GT) >1)
       warning("Values will be standardized to sum to 1")
-    if (!is.null(truncate)) {
-      if (truncate < length(val)) {
+    if (!is.null(truncate) && truncate < length(val)) {
         warning("Empirical distribution truncated at length ",truncate)
         GT <- GT[1:truncate]
-      }
     }
     # if parametric
   } else {
@@ -135,7 +133,7 @@ generation.time <- function(
     if (is.null(truncate)) {
       # truncate when GI distribution >0.9999
       GT.cum <- cumsum(GT)
-      if(length(GT.cum[GT.cum > 0.9999]) != 0){
+      if(any(GT.cum > 0.9999)){
         truncate <- (GT.cum > 0.9999)*(seq_along(GT.cum))
         truncate <- min(truncate[truncate > 0])
         if (truncate == 0) warning('provide truncate larger than ',mean + 10 * sd)

--- a/R/generation.time.R
+++ b/R/generation.time.R
@@ -136,7 +136,7 @@ generation.time <- function(
       # truncate when GI distribution >0.9999
       GT.cum <- cumsum(GT)
       if(length(GT.cum[GT.cum > 0.9999]) != 0){
-        truncate <- (GT.cum > 0.9999)*(1:length(GT.cum))
+        truncate <- (GT.cum > 0.9999)*(seq_along(GT.cum))
         truncate <- min(truncate[truncate > 0])
         if (truncate == 0) warning('provide truncate larger than ',mean + 10 * sd)
         GT <- GT[1:truncate]

--- a/R/generation.time.R
+++ b/R/generation.time.R
@@ -82,7 +82,7 @@ generation.time <- function(
       warning("Values will be standardized to sum to 1")
     if (!is.null(truncate)) {
       if (truncate < length(val)) {
-        warning(paste("Empirical distribution truncated at length ",truncate))
+        warning("Empirical distribution truncated at length ",truncate)
         GT <- GT[1:truncate]
       }
     }
@@ -138,7 +138,7 @@ generation.time <- function(
       if(length(GT.cum[GT.cum > 0.9999]) != 0){
         truncate <- (GT.cum > 0.9999)*(1:length(GT.cum))
         truncate <- min(truncate[truncate > 0])
-        if (truncate == 0) warning(paste('provide truncate larger than ',mean + 10 * sd))
+        if (truncate == 0) warning('provide truncate larger than ',mean + 10 * sd)
         GT <- GT[1:truncate]
       }
     }

--- a/R/inspect.data.R
+++ b/R/inspect.data.R
@@ -91,14 +91,14 @@ inspect.data <- function(
       if (is.na(incid[1])) {
         idx.last.leading.missing <- diff(cumsum(is.na(incid)))
         idx.last.leading.missing <- 1 + sum(idx.last.leading.missing[1:(min(which(idx.last.leading.missing == 0)) - 1)])
-        warning(paste0("There are trailing missing values in your data. Consider subsetting to remove data points 1 through ", idx.last.leading.missing, "."))
+        warning("There are trailing missing values in your data. Consider subsetting to remove data points 1 through ", idx.last.leading.missing, ".")
       }
       
       # Trailing NAs are detected the same way on the reversed incid vector
       if (is.na(incid[length(incid)])) {
         idx.last.trailing.missing <- diff(cumsum(is.na(rev(incid))))
         idx.last.trailing.missing <- sum(idx.last.trailing.missing[1:(min(which(idx.last.trailing.missing == 0)) - 1)])
-        warning(paste0("There are trailing missing values in your data. Consider subsetting to remove data points ", length(incid) - idx.last.trailing.missing, " through ", length(incid), "."))
+        warning("There are trailing missing values in your data. Consider subsetting to remove data points ", length(incid) - idx.last.trailing.missing, " through ", length(incid), ".")
       }
       
       # If GT is provided, check that NAs do not exceed its length, which would result in failed optimization routines.
@@ -121,14 +121,14 @@ inspect.data <- function(
       if (epid$incid[1] == 0) {
         idx.last.leading.zero <- diff(cumsum(epid$incid == 0))
         idx.last.leading.zero <- 1 + sum(idx.last.leading.zero[1:(min(which(idx.last.leading.zero == 0)) - 1)])
-        warning(paste0("There are leading zeros in your data. Consider subsetting to remove data points 1 through ", idx.last.leading.zero, "."))
+        warning("There are leading zeros in your data. Consider subsetting to remove data points 1 through ", idx.last.leading.zero, ".")
       }
       
       # Trailing zeros should not be too much of an issue, but are still checked
       if (epid$incid[length(incid)] == 0) {
         idx.last.trailing.zero <- diff(cumsum(rev(epid$ncid) == 0))
         idx.last.trailing.zero <- sum(idx.last.trailing.zero[1:(min(which(idx.last.trailing.zero == 0)) - 1)])
-        warning(paste0("There are trailing zeros in your data. Consider subsetting to remove data points ", length(epid$incid) - idx.last.trailing.zero, " through ", length(epid$incid), "."))
+        warning("There are trailing zeros in your data. Consider subsetting to remove data points ", length(epid$incid) - idx.last.trailing.zero, " through ", length(epid$incid), ".")
       }
       
       # If GT is provided, check that consecutive 0s do not exceed its length

--- a/R/inspect.data.R
+++ b/R/inspect.data.R
@@ -84,7 +84,7 @@ inspect.data <- function(
       warning("Data does not consist only of integer values. Consider rounding to avoid computational issues.")
     }
     
-    if (any(is.na(incid))) {
+    if (anyNA(incid)) {
       warning("Warning: your data contains missing values. These will be automatically converted to zeros by check.incid() and may affect your estimates.")
       
       # Leading NAs are detected if 1st value is NA

--- a/R/integrity.checks.R
+++ b/R/integrity.checks.R
@@ -87,21 +87,14 @@ integrity.checks <- function(
     
     # Various class and integrity checks are ran
     #check generation time (can be omitted if method is limited to AR)
-    if (length(methods) == 1) {
-      if (methods != "AR") {
-        if (!inherits(GT, "R0.GT")) {
-          stop("'GT' must be provided as a GT class object.")
-        }
-      }
+    if (!identical(methods, "AR") && !inherits(GT, "R0.GT")) {
+      stop("'GT' must be provided as a GT class object.")
     }
     
     #Checks on 'begin' and 'end'
-    if (!is.null(begin) && !is.null(end)) {
-      # if begin and end are not null
-      if (class(begin) != class(end)) {
-        # must be of the same class 
-        stop("If both 'begin' = ",begin," and 'end' = ", end, " are provided, they must be of the same class (dates, character strings or integers).")
-      }
+    if (!is.null(begin) && !is.null(end) && class(begin) != class(end)) {
+      # must be of the same class 
+      stop("If both 'begin' = ",begin," and 'end' = ", end, " are provided, they must be of the same class (dates, character strings or integers).")
     }
     
     if ((is.character(begin) || is.character(end) || inherits(begin, "Date") || inherits(end, "Date")) && !inherits(tmp.epid$t, "Date")) {

--- a/R/integrity.checks.R
+++ b/R/integrity.checks.R
@@ -123,9 +123,9 @@ integrity.checks <- function(
     } else if (inherits(begin, "Date")) {
       begin.nb <- which(tmp.epid$t == begin)
     } else if (is.character(begin)) { # try to convert using standard formats
-      tmp.begin <- try(as.Date(begin, format = "%Y-%m-%d"),silent=T)
+      tmp.begin <- try(as.Date(begin, format = "%Y-%m-%d"),silent=TRUE)
       if (inherits(tmp.begin, "Date")) begin <- tmp.begin
-      tmp.begin <- try(as.Date(begin, format = "%d/%m/%Y"),silent=T)
+      tmp.begin <- try(as.Date(begin, format = "%d/%m/%Y"),silent=TRUE)
       if (inherits(tmp.begin, "Date")) begin <- tmp.begin
       begin.nb <- which(tmp.epid$t == begin)
     } 
@@ -157,9 +157,9 @@ integrity.checks <- function(
     } else if (inherits(end, "Date")) {
       end.nb <- which(tmp.epid$t == end)
     } else if (is.character(end)) { # try to convert using standard formats
-      tmp.end <- try(as.Date(end,format = "%Y-%m-%d"),silent=T)
+      tmp.end <- try(as.Date(end,format = "%Y-%m-%d"),silent=TRUE)
       if (inherits(tmp.end, "Date")) end <- tmp.end
-      tmp.end <- try(as.Date(end,format = "%d/%m/%Y"),silent=T)
+      tmp.end <- try(as.Date(end,format = "%d/%m/%Y"),silent=TRUE)
       if (inherits(tmp.end, "Date")) end <- tmp.end
       end.nb <- which(tmp.epid$t == end)
     } 

--- a/R/integrity.checks.R
+++ b/R/integrity.checks.R
@@ -78,7 +78,7 @@ integrity.checks <- function(
 
 {
   #Integrity checks are different for AR and other methods.
-  if ("EG" %in% methods | "ML" %in% methods | "TD" %in% methods | "SB" %in% methods) {
+  if ("EG" %in% methods || "ML" %in% methods || "TD" %in% methods || "SB" %in% methods) {
     #Computes the date vector with date.first.obs
     if (!is.null(date.first.obs)) {
       date.first.obs = as.Date(date.first.obs)
@@ -96,7 +96,7 @@ integrity.checks <- function(
     }
     
     #Checks on 'begin' and 'end'
-    if (!is.null(begin) & !is.null(end)) {
+    if (!is.null(begin) && !is.null(end)) {
       # if begin and end are not null
       if (class(begin) != class(end)) {
         # must be of the same class 
@@ -104,7 +104,7 @@ integrity.checks <- function(
       }
     }
     
-    if ((is.character(begin) | is.character(end) | inherits(begin, "Date") | inherits(end, "Date")) & !inherits(tmp.epid$t, "Date")) {
+    if ((is.character(begin) || is.character(end) || inherits(begin, "Date") || inherits(end, "Date")) && !inherits(tmp.epid$t, "Date")) {
       # begin ou end ne peuvent ?tre des dates que si t est une date
       stop("'begin' or 'end' may be provided as dates only if 'epid' or 't' contains dates.")
       
@@ -117,7 +117,7 @@ integrity.checks <- function(
       begin <- tmp.epid$t[1]
     } else if (is.numeric(begin)) {
       # begin is given 
-      if ((begin <1) | begin > length(tmp.epid$t)) begin=1
+      if ((begin <1) || begin > length(tmp.epid$t)) begin=1
       begin.nb <- begin
       begin <- tmp.epid$t[begin]
     } else if (inherits(begin, "Date")) {
@@ -151,7 +151,7 @@ integrity.checks <- function(
       # end is given 
       # provide default value for end.nb
       end.nb <- end
-      if ((end.nb < begin.nb) | (end > length(tmp.epid$t))) end = end.nb
+      if ((end.nb < begin.nb) || (end > length(tmp.epid$t))) end = end.nb
       if (end.nb <= begin.nb) end <- length(tmp.epid$t)
       end <- tmp.epid$t[end.nb]
     } else if (inherits(end, "Date")) {
@@ -174,11 +174,11 @@ integrity.checks <- function(
   
   #If method is only AR, checks if arguments are consistent
   else {
-    if ((!is.null(S0)) && (S0 < 0 | S0 > 1)) {
+    if ((!is.null(S0)) && (S0 < 0 || S0 > 1)) {
       stop("S0 should only take value between 0 and 1.")
     }
     
-    if ((!is.null(AR)) && (AR < 0 | AR > S0)) {
+    if ((!is.null(AR)) && (AR < 0 || AR > S0)) {
       stop("AR should only take value between 0 and S0")
     }
   }

--- a/R/integrity.checks.R
+++ b/R/integrity.checks.R
@@ -92,7 +92,7 @@ integrity.checks <- function(
     }
     
     #Checks on 'begin' and 'end'
-    if (!is.null(begin) && !is.null(end) && class(begin) != class(end)) {
+    if (!is.null(begin) && !is.null(end) && !identical(class(begin), class(end))) {
       # must be of the same class 
       stop("If both 'begin' = ",begin," and 'end' = ", end, " are provided, they must be of the same class (dates, character strings or integers).")
     }

--- a/R/integrity.checks.R
+++ b/R/integrity.checks.R
@@ -100,7 +100,7 @@ integrity.checks <- function(
       # if begin and end are not null
       if (class(begin) != class(end)) {
         # must be of the same class 
-        stop(paste("If both 'begin' =",begin," and 'end'=", end, "are provided, they must be of the same class (dates, character strings or integers)."))
+        stop("If both 'begin' = ",begin," and 'end' = ", end, " are provided, they must be of the same class (dates, character strings or integers).")
       }
     }
     

--- a/R/plot.R0.R.R
+++ b/R/plot.R0.R.R
@@ -55,7 +55,7 @@ plot.R0.R <- function(
   
   #Adjust arguments depending on method
   if(x$method.code %in% c("EG", "ML", "AR")) {
-      do.call(paste("plotR",x$method.code,sep=""), args=list(x=x, ...) )
+      do.call(paste0("plotR",x$method.code), args=list(x=x, ...) )
     } else if (x$method.code == "SB") {
       do.call("plotRSB", args=list(x=x, xscale=xscale, ...) )
     } else if (x$method.code == "TD") {

--- a/R/plot.R0.R.R
+++ b/R/plot.R0.R.R
@@ -261,7 +261,7 @@ plotRTD <- function(
   #What should labels say
   lab <- format(pretty(epid$t, n=length(epid$t)/div))
   
-  if (TD.split == TRUE) {
+  if (TD.split) {
     #par(bg="white")
     split.screen(c(2,1))
     screen(1)
@@ -283,7 +283,7 @@ plotRTD <- function(
   #points(epid$t, Rt.quant$CI.upper.[1:length(epid$t)], col="red", xaxt="n", pch=NA_integer_)
   axis(1, at=atLab, labels=lab)
   
-  if (TD.split == TRUE) {
+  if (TD.split) {
     close.screen(split.screen())
   }
 }

--- a/R/plot.R0.R.R
+++ b/R/plot.R0.R.R
@@ -253,7 +253,7 @@ plotRTD <- function(
   epid <- x$epid
   epid$t <- epid$t[x$begin.nb:(x$end.nb-1)]
   polygon.x <- c(epid$t, rev(epid$t))
-  polygon.y <- c(x$conf.int[1:length(epid$t),1], rev(x$conf.int[1:length(epid$t),2]))
+  polygon.y <- c(x$conf.int[seq_along(epid$t),1], rev(x$conf.int[seq_along(epid$t),2]))
   
   div <- get.scale(xscale)
   #Where should labels be on axis
@@ -272,15 +272,15 @@ plotRTD <- function(
     axis(1, at=atLab, labels=lab)
     screen(2)
   }
-  plot(epid$t, R[1:length(epid$t)], ylim=c(0, max(polygon.y)), xlab="Time", ylab="R(t)", xaxt="n", pch=NA_integer_, lty="blank", main=paste("Reproduction number (", x$method,")"), ...)
+  plot(epid$t, R[seq_along(epid$t)], ylim=c(0, max(polygon.y)), xlab="Time", ylab="R(t)", xaxt="n", pch=NA_integer_, lty="blank", main=paste("Reproduction number (", x$method,")"), ...)
   polygon(polygon.x, polygon.y, col="gray", border=NA)
-  lines(epid$t, R[1:length(epid$t)])
+  lines(epid$t, R[seq_along(epid$t)])
   abline(h=1, lty="dashed", col="gray40")
   
   #Blue = lowest quantile (default: 5%)
   #Red = highest quantile (default: 95%)
-  #points(epid$t, Rt.quant$CI.lower.[1:length(epid$t)], col="blue", xaxt="n", pch=NA_integer_)
-  #points(epid$t, Rt.quant$CI.upper.[1:length(epid$t)], col="red", xaxt="n", pch=NA_integer_)
+  #points(epid$t, Rt.quant$CI.lower.[seq_along(epid$t)], col="blue", xaxt="n", pch=NA_integer_)
+  #points(epid$t, Rt.quant$CI.upper.[seq_along(epid$t)], col="red", xaxt="n", pch=NA_integer_)
   axis(1, at=atLab, labels=lab)
   
   if (TD.split) {
@@ -331,13 +331,13 @@ plotRSB <- function(
   
   epid$t = epid$t[x$begin.nb:(x$end.nb-1)]
   polygon.x = c(epid$t, rev(epid$t))
-  polygon.y = c(x$conf.int[1:length(epid$t),1], rev(x$conf.int[1:length(epid$t),2]))
+  polygon.y = c(x$conf.int[seq_along(epid$t),1], rev(x$conf.int[seq_along(epid$t),2]))
   
-  #plot(epid$t, Rt.quant$R.t.[1:length(epid$t)], ylim=c(0, max(polygon.y)), xlab="Time", ylab="R(t)", xaxt="n", main=paste("Reproduction number (", x$method,")"),...)
-  plot(epid$t, R[1:length(epid$t)], ylim=c(0, max(polygon.y)), xlab="Time", ylab="R(t)", xaxt="n", pch=NA_integer_, lty="blank", 
+  #plot(epid$t, Rt.quant$R.t.[seq_along(epid$t)], ylim=c(0, max(polygon.y)), xlab="Time", ylab="R(t)", xaxt="n", main=paste("Reproduction number (", x$method,")"),...)
+  plot(epid$t, R[seq_along(epid$t)], ylim=c(0, max(polygon.y)), xlab="Time", ylab="R(t)", xaxt="n", pch=NA_integer_, lty="blank", 
        main=paste("Reproduction number (", x$method,")"), ...)
   polygon(polygon.x, polygon.y, col="gray", border=NA)
-  lines(epid$t, R[1:length(epid$t)])
+  lines(epid$t, R[seq_along(epid$t)])
   abline(h=1, lty="dashed", col="gray40")
   
   div = get.scale(xscale)

--- a/R/plot.R0.S.R
+++ b/R/plot.R0.S.R
@@ -91,7 +91,7 @@ plot.R0.S <- function(
   
   #Plotting heatmap
 	filled.contour(x=x$begin, y=x$end, z=t(x$mat.sen), color.palette=function(t) rev(heat.colors(t)), key.title=(title(main="R0")),                  
-    plot.axes={contour(x=x$begin, y=x$end, z=t(x$mat.sen), levels=c(best.fit$CI.lower, best.fit$CI.upper), lwd=2, add=T); 
+    plot.axes={contour(x=x$begin, y=x$end, z=t(x$mat.sen), levels=c(best.fit$CI.lower, best.fit$CI.upper), lwd=2, add=TRUE); 
     axis(1, x$begin);
     axis(2, x$end);
     points(which(x$epid$t == best.fit$Begin.dates), which(x$epid$t == best.fit$End.dates), pch=19);

--- a/R/plot.R0.sR.R
+++ b/R/plot.R0.sR.R
@@ -57,7 +57,7 @@ plot.R0.sR <- function(
   }
   
   #If invalid scale parameter is used, stop.
-  if (xscale != "d" & xscale != "w" & xscale !="f" & xscale != "m") {
+  if (xscale != "d" && xscale != "w" && xscale !="f" && xscale != "m") {
     stop("Invalid scale parameter.")
   }
   

--- a/R/plotfit.R0.R.R
+++ b/R/plotfit.R0.R.R
@@ -250,7 +250,7 @@ plotfitRSB <- function(
   axis(1, at=atLab, labels=lab)
   
   #When plotting Bayesian, if SB.dist is enabled, plot some R distributions throughout the epidemic
-  if (SB.dist == TRUE) {
+  if (SB.dist) {
     #x11()
     dev.new()
     split.screen(c(3,3))

--- a/R/plotfit.R0.R.R
+++ b/R/plotfit.R0.R.R
@@ -260,7 +260,7 @@ plotfitRSB <- function(
     else {
       num.to.plot <- c(begin.nb:end.nb)
     }
-    for (i in 1:length(num.to.plot)) {
+    for (i in seq_along(num.to.plot)) {
       if (i == 1) {
         screen(1)
         plot(y=x$proba.Rt[[num.to.plot[i]]], x=seq(from=0, to=(length(x$proba.Rt[[num.to.plot[i]]])/100-0.01), by=0.01), xlab="R value", ylab="PDF", type="l", main=paste("t=",num.to.plot[i]), ...)

--- a/R/plotfit.R0.R.R
+++ b/R/plotfit.R0.R.R
@@ -55,7 +55,7 @@ plotfit.R0.R <- function(
     do.call(plotfitRxx, args=list(x=x, xscale=xscale, ...) )
   }
   else {
-    do.call(paste("plotfitR",x$method.code,sep=""), args=list(x=x, xscale=xscale, SB.dist=SB.dist, ...) )
+    do.call(paste0("plotfitR",x$method.code), args=list(x=x, xscale=xscale, SB.dist=SB.dist, ...) )
   }
   
 }

--- a/R/plotfit.R0.sR.R
+++ b/R/plotfit.R0.sR.R
@@ -54,7 +54,7 @@ plotfit.R0.sR <- function(
   }
   
   #If invalid scale parameter is used, stop.
-  if (xscale != "d" & xscale != "w" & xscale !="f" & xscale != "m") {
+  if (xscale != "d" && xscale != "w" && xscale !="f" && xscale != "m") {
     stop("Invalid scale parameter.")
   }
   

--- a/R/print.R0.R.R
+++ b/R/print.R0.R.R
@@ -56,7 +56,7 @@ print.R0.R <- function(
   if (x$method.code %in% c("EG","ML","AR")) {
     cat("R : ",x$R)
     
-    if (!any(is.na(x$conf.int))) {
+    if (!anyNA(x$conf.int)) {
       cat("[", x$conf.int[1],",",x$conf.int[2],"]\n")
     }
   } 

--- a/R/print.R0.R.R
+++ b/R/print.R0.R.R
@@ -64,7 +64,7 @@ print.R0.R <- function(
   else {
     #Must be TD/SB... output first 10 values
     if (x$method.code %in% c("TD","SB")) {
-      cat(x$R[1:min(length(x$R),10)],"...\n")
+      cat(x$R[seq_len(min(length(x$R),10))],"...\n")
     }
   }
   

--- a/R/sa.GT.R
+++ b/R/sa.GT.R
@@ -71,7 +71,7 @@ sa.GT <- function(
   res <- list()
   
   #Is estimation method supported?
-  if ((est.method %in% c("EG", "ML")) == FALSE) {
+  if (!est.method %in% c("EG", "ML")) {
     stop("Argument 'est.method' should be any of 'EG' or 'ML' to produce results.")
   }
   

--- a/R/sa.GT.R
+++ b/R/sa.GT.R
@@ -76,8 +76,8 @@ sa.GT <- function(
   }
   
   count = 1
-  for (i in 1:length(GT.mean.range)) {
-    for (j in 1:length(GT.sd.range)) {
+  for (i in seq_along(GT.mean.range)) {
+    for (j in seq_along(GT.sd.range)) {
       list.GT[[count]] <- generation.time(GT.type, c(GT.mean.range[[i]], GT.sd.range[j]))
       count <- count+1
     }
@@ -92,7 +92,7 @@ sa.GT <- function(
   #Columns are named so that display is easy to read
   colnames(s.a) <- c("GT.Type", "GT.Mean", "GT.SD", "R", "CI.lower", "CI.upper")
   
-  for(i in 1:length(list.GT)) {
+  for(i in seq_along(list.GT)) {
     #Simulation is ran according to the requested method, with each correct begin/end value
     res <- estimate.R(incid, list.GT[[i]], begin=begin, end=end, t=t, date.first.obs=date.first.obs, time.step=time.step, methods=est.method,...)
     

--- a/R/sa.time.R
+++ b/R/sa.time.R
@@ -78,7 +78,7 @@ sa.time <- function(
     if (!inherits(res, "R0.R")) {
       stop("Currently, sensitivity analysis from a result object only supports 'R0.R' class objects. Try using res$estimates$EG or res$estimates$ML if they are defined.")
     }
-    else if ((res$method %in% c("Exponential Growth","Maximum Likelihood")) == FALSE) {
+    else if (!res$method %in% c("Exponential Growth","Maximum Likelihood")) {
       stop("Sensitivity analysis can only be conducted on objects with method EG or ML.")
     }
     else if (res$method == "Exponential Growth") {
@@ -105,7 +105,7 @@ sa.time <- function(
   if (is.null(est.method)) {
     stop("Argument est.method should be 'EG' or 'ML'")
   }
-  else if ((est.method %in% c("EG","ML")) == FALSE) {
+  else if (!est.method %in% c("EG","ML")) {
     stop("Argument est.method should be 'EG' or 'ML'")
   }
   

--- a/R/sa.time.R
+++ b/R/sa.time.R
@@ -120,8 +120,8 @@ sa.time <- function(
   #Columns are named so that display is easy to read
   colnames(s.a) <- c("Time.period", "Begin.dates","End.dates","R", "Growth.rate", "Rsquared", "CI.lower", "CI.upper")
   
-  for(i in 1:length(begin)) {
-    for(j in 1:length(end)) {
+  for(i in seq_along(begin)) {
+    for(j in seq_along(end)) {
       
       #Skip test if begin>=end, and correspondig cells are filled with NA in matrix
       #if ((begin[i]>=end[j]) | (end[j] == (begin[i]+1))) {

--- a/R/sa.time.R
+++ b/R/sa.time.R
@@ -87,7 +87,7 @@ sa.time <- function(
     else if (res$method == "Maximum Likelihood") {
       est.method <- "ML"
     }
-    if (is.null(begin) | is.null(end)) {
+    if (is.null(begin) || is.null(end)) {
       stop("Arguments \"begin\" and \"end\" must both be provided as vectors of index dates.")
     }
     
@@ -95,7 +95,7 @@ sa.time <- function(
     GT <- res$GT
   }
   
-  if (is.null(begin) | is.null(end)) {
+  if (is.null(begin) || is.null(end)) {
     stop("'begin' and/or 'end' is/are missing.")
   }
   

--- a/R/sensitivity.analysis.R
+++ b/R/sensitivity.analysis.R
@@ -83,7 +83,7 @@ sensitivity.analysis <- function(
   }
   
   else if ((sa.type == "time") && (is.null(res))) {
-    if ((is.null(GT)) | (is.null(est.method))) {
+    if ((is.null(GT)) || (is.null(est.method))) {
       stop("Missing input argument (probably GT or est.method). Please check sa.time documentation for further details.")
     }
     else {
@@ -92,7 +92,7 @@ sensitivity.analysis <- function(
     
   }
   else if (sa.type == "GT") {
-    if ((is.null(GT.type)) | (is.null(GT.mean.range)) | (is.null(GT.sd.range)) | (is.null(est.method))) {
+    if ((is.null(GT.type)) || (is.null(GT.mean.range)) || (is.null(GT.sd.range)) || (is.null(est.method))) {
       stop("Missing input argument (probably GT.type, GT.mean.range, GT.sd.range or est.method). Please check sa.time documentation for further details.")
     }
     else {

--- a/R/sensitivity.analysis.R
+++ b/R/sensitivity.analysis.R
@@ -100,7 +100,7 @@ sensitivity.analysis <- function(
     }
   }
   else {
-    stop(paste("sa.type =",sa.type,"is not a valid argument. Must be \"time\" or \"GT\"."))
+    stop("sa.type = ",sa.type," is not a valid argument. Must be \"time\" or \"GT\".")
   }
   
   return(sa.object)

--- a/R/sim.epid.R
+++ b/R/sim.epid.R
@@ -69,7 +69,7 @@ sim.epid <- function(
   }
   
   #If negbin.size is omitted, size parameter is set so that variance = 10*R0. See details.
-  if (family=="negbin" & is.null(negbin.size)) {
+  if (family=="negbin" && is.null(negbin.size)) {
     negbin.size <- R0/4
   }
   GT <- GT$GT
@@ -98,7 +98,7 @@ sim.epid <- function(
       sim.epid[t:(t+length(GT)-1)] <- sim.epid[t:(t+length(GT)-1)]+newd
       
       # Threshold so that epidemics eventualy dies out
-      if (sim.epid[t+1] > peak.value & t < (epid.length-1)) {
+      if (sim.epid[t+1] > peak.value && t < (epid.length-1)) {
         
         #Changing the R value is like implementing control measure. Uncomment if want to doing so
         #R0 <- 0.7

--- a/R/sim.epid.indiv.R
+++ b/R/sim.epid.indiv.R
@@ -74,7 +74,7 @@ sim.epid.indiv <- function(
   }
   
   
-  epid <- data.frame(matrix(data=0, nrow=Lmax, ncol=5, dimnames=list(c(1:Lmax), c("tinf","nsec","dinf","dlat","runif"))))
+  epid <- data.frame(matrix(data=0, nrow=Lmax, ncol=5, dimnames=list(1:Lmax, c("tinf","nsec","dinf","dlat","runif"))))
   
   for (i in 1:n) {
     #Memory optimization: dinf and dlat are all computed at the beginning

--- a/R/sim.epid.indiv.R
+++ b/R/sim.epid.indiv.R
@@ -63,10 +63,10 @@ sim.epid.indiv <- function(
   if (beta <= 1.5) {
     Lmax <- 5000
   }
-  else if (beta <= 2 & beta > 1.5) {
+  else if (beta <= 2 && beta > 1.5) {
     Lmax <- 50000
   }
-  else if (beta <= 3 & beta > 2) {
+  else if (beta <= 3 && beta > 2) {
     Lmax <- 50000
   }
   else if (beta >3) {

--- a/R/smooth.Rt.R
+++ b/R/smooth.Rt.R
@@ -68,7 +68,7 @@ smooth.Rt <- function(
     stop("Sensitivity analysis can only be conducted on objects with method EG or ML.")
   }
   
-  if ((!is.numeric(time.period)) & (!is.integer(time.period))) {
+  if ((!is.numeric(time.period)) && (!is.integer(time.period))) {
     stop("Error: time.period should be of numeric or integer class.")
   }
   

--- a/R/smooth.Rt.R
+++ b/R/smooth.Rt.R
@@ -64,7 +64,7 @@ smooth.Rt <- function(
   if (!inherits(res, "R0.R")) {
     stop("Currently, sensitivity analysis from a result object only supports 'R0.R' class objects. Try using res$estimates$TD or res$estimates$SB if they are defined.")
   }
-  else if ((res$method %in% c("Time-Dependent","Sequential Bayesian")) == FALSE) {
+  else if (!res$method %in% c("Time-Dependent","Sequential Bayesian")) {
     stop("Sensitivity analysis can only be conducted on objects with method EG or ML.")
   }
   


### PR DESCRIPTION
This PR fixes some potential bugs or suboptimal code in terms of performance, as flagged by lintr.

As always, I recommend reviewing this PR commit by commit as each commit focuses on fixing one specific class of lint.

As far as I can tell, the only potentially controversial change is in 2db8434acf16c352681ca81a5d8dd43342f2cf54 which switches `any(is.na(x))` to the much more efficient `anyNA(x)`. However, this comes with a dependency on R 3.3.0. This version was released on 2016-05-03, almost 7 years ago and it's likely that many users were forced to upgrade since then to use the popular tidyverse packages (e.g., ggplot2 or dplyr) which require R 3.5. But the choice is ultimately yours. I can revert this commit if you're not comfortable with this change.

The lintr config used is saved in the last commit and the analysis done in this PR can be reproduced by running `lintr::lint_package()` in the package root.

The only lint I didn't disable but didn't fix either is `object_usage_linter`, which flags variables that are defined but never used. This is more difficult to find because it can either be completely benign or reveal an underlying bug. For this reason, I prefer leaving this task to you.

If you wish, I can also set up lintr to automatically run as part of your continuous integration pipeline, alongside the existing `R CMD check` workflow.