### PR TITLE
Added github url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,6 +4,7 @@ Title: Estimation of R0 and Real-Time Reproduction Number from Epidemics
 Version: 1.3-0
 Date: 2023-03-06
 Author: Pierre-Yves Boelle, Thomas Obadia
+URL: https://github.com/tobadia/R0
 Maintainer: Thomas Obadia <thomas.obadia@pasteur.fr>
 Depends:
     R (>= 2.13.0)


### PR DESCRIPTION
The github URL is added to the description. This will give cran users awareness of the GitHub location.