### PR TITLE
Encode Author & Maintainer as Authors@R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,9 +3,11 @@ Type: Package
 Title: Estimation of R0 and Real-Time Reproduction Number from Epidemics
 Version: 1.3-0
 Date: 2023-03-06
-Author: Pierre-Yves Boelle, Thomas Obadia
+Authors@R: c(
+    person("Pierre-Yves", "Boelle", role = "aut"), 
+    person("Thomas", "Obadia", role = c("aut", "cre"), email = "thomas.obadia@pasteur.fr")
+  )
 URL: https://github.com/tobadia/R0
-Maintainer: Thomas Obadia <thomas.obadia@pasteur.fr>
 Depends:
     R (>= 2.13.0)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Estimation of R0 and Real-Time Reproduction Number from Epidemics
 Version: 1.3-0
 Date: 2023-03-06
 Authors@R: c(
-    person("Pierre-Yves", "Boelle", role = "aut"), 
+    person("Pierre-Yves", "Boelle", role = "aut", comment = c(ORCID = "0000-0002-5367-8232")), 
     person("Thomas", "Obadia", role = c("aut", "cre"), email = "thomas.obadia@pasteur.fr")
   )
 URL: https://github.com/tobadia/R0


### PR DESCRIPTION
This follows some recommendations from Kurt Hornik, CRAN co-founder, at the useR2024! conference.

It is considered better practice to use `Authors@R` because it offers more granular control (e.g., what is first vs family name), which is even more important now that package metadata is submitted to crossref.

Documentation about this field: https://r-pkgs.org/description.html#sec-description-authors-at-r

From my end, I also use this data in https://epiverse-connect.github.io/ctv-analysis/